### PR TITLE
Fixed tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+# Retain LF endings for text files in data because they're used in hashing
+# tests and the tests will fail if the git rewrites the line endings
+data/**/*.txt text=auto eol=lf

--- a/evaporate.cabal
+++ b/evaporate.cabal
@@ -96,6 +96,7 @@ test-suite evaporate-test
                      , amazonka-s3
                      , either
                      , exceptions
+                     , filepath
                      , fgl
                      , hspec
                      , hspec-core


### PR DESCRIPTION
A few tests were broken on Windows because of:
- Git CRLF rewriting was changing some text files used in hashing tests. This has been disabled for those files
- Zip tests were failing due to using hardcoded Unix-style path separators. This has been changed to use an operator that chooses the correct separator based on the platform.