### PR TITLE
Adds Travis builds and deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,80 @@
+sudo: required
+
+os:
+  - linux
+  - osx
+
+services:
+  - docker
+
+language: generic
+
+env:
+  global:
+    - DOCKER_REPO=seek/evaporate;
+
+# Caching so the next build will be fast too
+cache:
+  directories:
+  - $HOME/.stack
+
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+
+before_install:
+  - set -e
+  - mkdir -p ~/.local/bin
+  - export PATH=$PATH:$HOME/.local/bin
+  # Download and unpack the stack executable
+  # Could use $TRAVIS_OS_NAME to get the right stack executable but it's
+  # probably better not to rely on that env var too much
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    travis_retry curl -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 -C ~/.local/bin '*/stack';
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack';
+    fi
+
+install:
+  # Build dependencies
+  - stack test --no-terminal --install-ghc --only-dependencies
+
+before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    rvm get head || true;
+    fi
+  - if [[ !  -z  $TRAVIS_TAG  ]]; then
+    VERSION=${TRAVIS_TAG//[\-a-zA-Z]/};
+    echo "Tag detected - updating cabal to match tag version $VERSION";
+    sed -i -e "s|\(^version:[[:space:]]*\)[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*|\1$VERSION|" evaporate.cabal;
+    fi
+
+script:
+  # Build the package, its tests and run the tests
+  - stack test --no-terminal --ghc-options -Wall
+  - BINARY=$(stack path --local-install-root)/bin/evaporate;
+
+before_deploy:
+  - ZIP_NAME=evaporate-$TRAVIS_OS_NAME-$TRAVIS_TAG.zip
+  - cp $BINARY .
+  - zip $ZIP_NAME evaporate README.md
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    mkdir -p .publish;
+    cp $BINARY .publish;
+    echo "Building docker container for $TRAVIS_TAG";
+    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD;
+    docker build -f build-publish.dockerfile -t "$DOCKER_REPO" .;
+    docker tag "$DOCKER_REPO" "$DOCKER_REPO:$TRAVIS_TAG";
+    echo "Pushing docker image $DOCKER_REPO:$TRAVIS_TAG";
+    docker push "$DOCKER_REPO";
+    fi
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  skip_cleanup: true
+  file: $ZIP_NAME
+  on:
+    tags: true


### PR DESCRIPTION
This PR adds in the .travis.yml which will enable builds, testing and deployment of evaporate for linux and osx.

Travis will only deploy to docker and github for tag builds, but we still get builds and tests for all other commits.

If the building and testing are successful, before uploading to Github releases, we push to docker hub using `before_deploy`. This means that if there was a problem with the docker push, the build will fail.

Since we are using tagging to create releases, travis will detect the tag version and overwrite the value in the cabal file before the build. Currently our tags have been in the format `v0.5.1.0`, but this feature will support pre-release tags (eg `v0.5.1.0-alpha`).

I have the whole pipeline working on a fork: [github](https://github.com/tmortiboy/evaporate/) [travis](https://travis-ci.org/tmortiboy/evaporate) [docker](https://hub.docker.com/r/tmortiboy/evaporate/)

However, we still need the following:

- [ ] Travis CI setting up for Seek-Org (if there isn't one already)
- [ ] Access to the Seek docker hub in the form of username and password
- [ ] Oauth token creation for Github release
- [ ] the docker credentials and Github token created as secure environment variables for travis
- [ ] Adding Travis build status icon to the README