### PR TITLE
Adds ability for us to cry in different regions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode7.3
+
 services:
   - docker
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ include its default bin path into your `$PATH`.
 
 ### Region
 
-The deployment region is read from the environment variable `AWS_REGION` or
-retrieved from the [Instance Identity Document](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html),
-otherwise it defaults to `us-east-1`.
+The deployment region is read from the environment variable `AWS_REGION`;
+retrieved from the [Instance Identity Document](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html);
+overridden for all stacks with `--default-region` option; otherwise it defaults to `us-east-1`.
+Additionally, each stack definition can specify its own deployment region.
 
 ### evaporate.yaml
 
@@ -65,6 +66,7 @@ definition. A stack definition consists of the following:
    (keys can be 127 characters max, values can be 255 characters max)
 1. (Optional) Files to upload to buckets created within previous stacks
 1. (Optional) A list of Capabilities needed by the stack, e.g., CAPABILITY_IAM
+1. (Optional) A deployment region that is used to override the default, e.g. us-east-1
 
 *NB:* The order of execution is determined based on stack output references.
 If there is a cyclic dependency within the stacks (e.g. stack2 references an

--- a/example/evaporate.yaml
+++ b/example/evaporate.yaml
@@ -36,6 +36,7 @@ evaporate-example-stack2: # Stack name
   template-path: stack-template2.json
   capabilities:
     - CAPABILITY_IAM
+  region: us-east-1
   tags:
     Project: "Death Star"
     Owner: "tarkin@theempire.net"

--- a/src/Evaporate.hs
+++ b/src/Evaporate.hs
@@ -127,9 +127,9 @@ processStacks context comm accountID stackDescriptions stackNameOption =
     processEachStack (stackDescription@StackDescription{..} : otherStacks) = do
       fileHashes <- HashMap.unions <$> traverse hashBucketFiles _s3upload
       local (cFileHashes .~ fileHashes) $ do
+        newContext <- asks $ cEnv %~ setRegion _region
         newOutputs <-
-          liftResourceT . runAWST (context & cEnv %~ setRegion _region) $
-            processStack comm accountID stackDescription
+          liftResourceT . runAWST newContext $ processStack comm accountID stackDescription
         local (cStackOutputs <>~ newOutputs) $ processEachStack otherStacks
 
     byStackName :: StackName -> StackDescription -> Bool

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -64,12 +64,14 @@ logStackName :: StackDescription -> Text
 logStackName StackDescription{..} =
   "\n    " <> getStackName _stackName
 
-logExecution :: Command -> StackName -> Text
-logExecution command StackName{..} =
+logExecution :: Command -> StackName -> Region -> Text
+logExecution command StackName{..} region =
      "\nExecuting "
   <> (pack . show $ command)
   <> " on "
   <> getStackName
+  <> " in "
+  <> toText region
   <> "...\n"
 
 logFileUpload :: Text -> Text -> BucketName -> Text

--- a/src/StackParameters.hs
+++ b/src/StackParameters.hs
@@ -28,6 +28,7 @@ import           Data.Text (unpack, Text, pack)
 import           Data.Tuple.Extra (dupe)
 import           Data.Vector (toList)
 import qualified Data.Yaml as Y
+import           Network.AWS.Types (Region)
 import           Network.AWS.Data.Text (fromText)
 import           Network.AWS.CloudFormation ( parameter
                                             , pParameterKey
@@ -88,6 +89,7 @@ data StackDescription = StackDescription {
   , _templatePath :: Text
   , _tags         :: Tags
   , _parameters   :: Environments
+  , _region       :: Maybe Region
   } deriving (Show, Eq)
 
 makeLenses ''BucketFiles
@@ -105,6 +107,7 @@ instance {-# OVERLAPPING #-} FromJSON [StackDescription] where
               <*> o .:  "template-path"
               <*> o .:? "tags" .!= mempty
               <*> o .:? "parameters" .!= mempty
+              <*> o .:? "region" .!= Nothing
 
 -- | Leaning on the Amazonka FromText instance for the Capability type
 -- but newtype wrapping into Capabilities to slightly weaken the coupling

--- a/test/LoggingSpec.hs
+++ b/test/LoggingSpec.hs
@@ -71,12 +71,14 @@ spec = describe "LoggingSpec" $ do
     it "can generate a command execution log message" $ do
       stackParams <- runExceptT . getStackParameters $ "test/valid.yaml"
       let desc = head . fromRight' $ stackParams
-      let logMessage = logExecution Create (_stackName desc)
+      let logMessage = logExecution Create (_stackName desc) Sydney
       logMessage `shouldBe`
            "\nExecuting "
         <> "Create"
         <> " on "
         <> "Stack1"
+        <> " in "
+        <> "ap-southeast-2"
         <> "...\n"
 
     it "can generate a stack outputs log message" $ do

--- a/test/StackDependencySpec.hs
+++ b/test/StackDependencySpec.hs
@@ -49,7 +49,7 @@ spec = describe "StackDependencySpec" $ do
         (== DependencyCycleDetected [[StackName "test-stack5", StackName "test-stack4", StackName "test-stack3"]])
 
   context "determining stack dependencies from parameter values" $ do
-    let sourceStack = StackDescription mempty (StackName "stack2") mempty mempty mempty mempty
+    let sourceStack = StackDescription mempty (StackName "stack2") mempty mempty mempty mempty Nothing
     let sourceStackNode = (1, sourceStack)
     it "returns a dependency if given a StackOutput" $ do
       let testParameterValue = StackOutput (StackOutputName (StackName "stack1") "outputName")
@@ -99,5 +99,5 @@ acyclicStackDependencyGraph = do
   makeStackDependencyGraph stackParameters "123412341234"
 
 testStackNodeMap :: StackNodeMap
-testStackNodeMap = [(StackName "stack1", (0, StackDescription (Capabilities []) (StackName "stack1") [] "some-path.yaml" [] []))
-                   ,(StackName "stack2", (1, StackDescription (Capabilities []) (StackName "stack2") [] "some-path.yaml" [] []))]
+testStackNodeMap = [(StackName "stack1", (0, StackDescription (Capabilities []) (StackName "stack1") [] "some-path.yaml" [] [] Nothing))
+                   ,(StackName "stack2", (1, StackDescription (Capabilities []) (StackName "stack2") [] "some-path.yaml" [] [] Nothing))]

--- a/test/region.yaml
+++ b/test/region.yaml
@@ -1,0 +1,4 @@
+a-stack-with-region:
+  template-path: "template.json"
+  region: ap-southeast-2
+  parameters: {}


### PR DESCRIPTION
![](https://pics.me.me/me-crying-in-different-locations-2646718.png)

Fixes https://github.com/seek-oss/evaporate/issues/20

Allows the region to be set for all stacks via the CLI using `--default-region us-east-1`.

Each stack can have its own region to override the default.