### PR TITLE
Upgrade lts

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,238 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: false
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: new_line
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: 18
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: false
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: false
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 100
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+language_extensions:
+  - DerivingStrategies
+  - DerivingVia
+  - FlexibleContexts
+  - GeneralizedNewtypeDeriving
+  - LambdaCase
+  - MultiParamTypeClasses
+  - QuasiQuotes
+  - RecordWildCards
+  - ScopedTypeVariables
+  - TemplateHaskell
+  - TupleSections

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
   # Could use $TRAVIS_OS_NAME to get the right stack executable but it's
   # probably better not to rely on that env var too much
   - travis_retry curl -sSL https://get.haskellstack.org/ | sh
+  - stack update
 
 install:
   # Build dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 
-osx_image: xcode7.3
+osx_image: xcode11.3
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 # Caching so the next build will be fast too
 cache:
   directories:
-  - $HOME/.stack
+    - $HOME/.stack
 
 addons:
   apt:
@@ -32,12 +32,7 @@ before_install:
   # Download and unpack the stack executable
   # Could use $TRAVIS_OS_NAME to get the right stack executable but it's
   # probably better not to rely on that env var too much
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    travis_retry curl -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 -C ~/.local/bin '*/stack';
-    fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack';
-    fi
+  - travis_retry curl -sSL https://get.haskellstack.org/ | sh
 
 install:
   # Build dependencies

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import Configuration (loadConfiguration)
-import Evaporate (execute)
+import           Configuration (loadConfiguration)
+import           Evaporate (execute)
 
 main :: IO ()
 main = loadConfiguration >>= execute

--- a/build-publish.dockerfile
+++ b/build-publish.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER SEEK Ltd.
 
 RUN apt-get update &&

--- a/build-publish.dockerfile
+++ b/build-publish.dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER SEEK Ltd.
 
-RUN apt-get update \
-	&& apt-get install -y libgmp-dev curl \
-	&& apt-get clean
+RUN apt-get update &&
+	apt-get install -y libgmp-dev curl &&
+	apt-get clean
 
 # Needed to avoid exceptions when printing unicode to stdout/stderr
 ENV LC_ALL C.UTF-8

--- a/evaporate.cabal
+++ b/evaporate.cabal
@@ -59,6 +59,7 @@ library
                      , text
                      , transformers
                      , trifecta
+                     , unliftio-core
                      , unordered-containers
                      , vector
                      , yaml

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -1,33 +1,14 @@
 module Configuration where
 
-import           Data.Monoid ((<>))
-import           Data.Version (showVersion)
 import           Data.Text (Text, pack, unpack)
+import           Data.Version (showVersion)
+import qualified Network.AWS.CloudFormation.Types as CFN
 import           Network.AWS.Data.Text (fromText)
 import           Network.AWS.Types (LogLevel(..), Region)
-import qualified Network.AWS.CloudFormation.Types as CFN
-import           Options.Applicative ( info
-                                     , helper
-                                     , progDesc
-                                     , long
-                                     , short
-                                     , help
-                                     , metavar
-                                     , strArgument
-                                     , showDefault
-                                     , subparser
-                                     , execParser
-                                     , flag
-                                     , value
-                                     , optional
-                                     , infoOption
-                                     , hidden
-                                     , str
-                                     , eitherReader
-                                     , Parser
-                                     , ReadM
-                                     , ParserInfo(..)
-                                     )
+import           Options.Applicative
+                  (Parser, ParserInfo(..), ReadM, eitherReader, execParser, flag, help, helper,
+                  hidden, info, infoOption, long, metavar, optional, progDesc, short, showDefault,
+                  str, strArgument, subparser, value)
 import qualified Options.Applicative.Builder as OB
 
 import qualified Paths_evaporate as PackageInfo

--- a/src/FileSystem.hs
+++ b/src/FileSystem.hs
@@ -5,19 +5,15 @@ module FileSystem
   , sourceFileOrDirectory
   ) where
 
-import Conduit (runConduitRes
-              , sourceDirectoryDeep
-              , sinkList
-              , Producer
-              , yield)
-import Control.Exception.Safe (throwM)
-import Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.Trans.Resource (MonadResource)
-import Data.Conduit ((.|))
-import Data.Text (pack)
-import System.Directory (doesDirectoryExist, doesFileExist)
+import           Conduit (ConduitT, runConduitRes, sinkList, sourceDirectoryDeep, yield)
+import           Control.Exception.Safe (throwM)
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Resource (MonadResource)
+import           Data.Conduit ((.|))
+import           Data.Text (pack)
+import           System.Directory (doesDirectoryExist, doesFileExist)
 
-import Types (PathType(..), FileOrFolderDoesNotExist(..))
+import           Types (FileOrFolderDoesNotExist(..), PathType(..))
 
 getFilesFromFolder :: FilePath -> IO [FilePath]
 getFilesFromFolder folderPath = runConduitRes $
@@ -36,7 +32,7 @@ checkPath path = liftIO $ do
 -- | Deeply stream the contents of the given directory.
 -- This works the same as sourceDirectoryDeep, except if the path is a File not a Directory then
 -- it will yield just that file.
-sourceFileOrDirectory :: MonadResource m => Bool -> FilePath -> Producer m FilePath
+sourceFileOrDirectory :: MonadResource m => Bool -> FilePath -> ConduitT i FilePath m ()
 sourceFileOrDirectory followSymlinks path = do
   fileType <- checkPath path
   case fileType of

--- a/src/Logging.hs
+++ b/src/Logging.hs
@@ -3,24 +3,19 @@ module Logging where
 import           Control.Lens.Indexed (ifoldMap)
 import           Control.Monad (when)
 import           Control.Monad.IO.Class (MonadIO(..))
-import           Data.ByteString.Builder (hPutBuilder, toLazyByteString, Builder)
+import           Data.ByteString.Builder (Builder, hPutBuilder, toLazyByteString)
 import qualified Data.ByteString.Lazy.Char8 as BS
-import           Data.Monoid ((<>))
-import           Data.Text (Text, unpack, pack)
+import           Data.Text (Text, pack, unpack)
 import           Data.Text.Encoding (encodeUtf8)
 import           Network.AWS.Data.Text (toText)
 import           Network.AWS.S3.Types (BucketName(..))
-import           Network.AWS.Types (Logger, Region, LogLevel(..))
+import           Network.AWS.Types (LogLevel(..), Logger, Region)
+import           System.IO (BufferMode(..), Handle, hSetBinaryMode, hSetBuffering)
 import           System.Log.Logger (infoM)
-import           System.IO (hSetBinaryMode, hSetBuffering, Handle, BufferMode(..))
 
 import           Configuration (Command(..))
 import           StackParameters (StackDescription(..))
-import           Types ( AWSAccountID
-                       , StackOutputs
-                       , StackName(..)
-                       , StackOutputName(..)
-                       )
+import           Types (AWSAccountID, StackName(..), StackOutputName(..), StackOutputs)
 
 type Filters = [Text]
 

--- a/src/S3.hs
+++ b/src/S3.hs
@@ -7,21 +7,19 @@ module S3( uploadFileOrFolder
 
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO(..))
-import           Control.Monad.Trans.AWS (send, AWSConstraint)
+import           Control.Monad.Trans.AWS (AWSConstraint, send)
 import           Data.Foldable (traverse_)
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Text (pack, unpack, Text)
-import           Network.AWS ( chunkedFile
-                             , defaultChunkSize
-                             )
+import           Data.Text (Text, pack, unpack)
+import           Network.AWS (chunkedFile, defaultChunkSize)
 import qualified Network.AWS.S3 as S3
 import           Network.AWS.S3.Types (BucketName(..))
-import           System.FilePath.Posix ((</>), addTrailingPathSeparator)
+import           System.FilePath.Posix (addTrailingPathSeparator, (</>))
 
+import           FileSystem (checkPath, getFilesFromFolder)
 import           Logging (logEvaporate, logFileUpload)
 import           StackParameters (BucketFiles(..))
 import           Types (PathType(..))
-import           FileSystem (getFilesFromFolder, checkPath)
 
 uploadBucketFiles :: AWSConstraint r m => BucketFiles -> m ()
 uploadBucketFiles bucketFiles =

--- a/src/STS.hs
+++ b/src/STS.hs
@@ -1,8 +1,8 @@
 module STS where
 
-import           Control.Exception.Safe (throwM, Exception(..))
+import           Control.Exception.Safe (Exception(..), throwM)
 import           Control.Lens (view)
-import           Control.Monad.Trans.AWS (send, AWSConstraint)
+import           Control.Monad.Trans.AWS (AWSConstraint, send)
 import           Data.Typeable (Typeable)
 import qualified Network.AWS.STS as AWSSTS
 

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -1,32 +1,24 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Stack where
 
 import           Control.Applicative (Alternative, empty)
 import           Control.Error.Util (hush)
-import           Control.Exception.Safe (throwM, MonadThrow, Exception(..))
-import           Control.Lens ((&), (.~), (?~), (^.), filtered, Traversal')
+import           Control.Exception.Safe (Exception(..), MonadThrow, throwM)
+import           Control.Lens (Traversal', filtered, (&), (.~), (?~), (^.))
 import           Control.Monad (void)
-import           Control.Monad.Trans.AWS (send, await, AWSConstraint)
+import           Control.Monad.Trans.AWS (AWSConstraint, await, send)
 import           Control.Monad.Trans.Maybe (MaybeT(..))
-import           Data.Monoid ((<>))
-import           Data.Text (unpack, Text)
+import           Data.Text (Text, unpack)
 import qualified Data.Text as Text
 import           Data.Typeable (Typeable)
-import           Network.AWS (trying, catching)
+import           Network.AWS (catching, trying)
 import qualified Network.AWS.CloudFormation as CF
 import qualified Network.AWS.CloudFormation.Types as CFN
-import           Network.AWS.Types ( serviceCode
-                                   , serviceMessage
-                                   , AsError
-                                   , AWSRequest
-                                   , AsError(..)
-                                   , ServiceError(..)
-                                   , ErrorMessage(..)
-                                   , ErrorCode(..)
-                                   , Error(ServiceError)
-                                   )
+import           Network.AWS.Types
+                  (AWSRequest, AsError(..), Error(ServiceError), ErrorCode(..), ErrorMessage(..),
+                  ServiceError(..), serviceCode, serviceMessage)
 import           Network.AWS.Waiter (Accept(..), Wait(..))
 import           Network.HTTP.Types.Status (statusCode)
 

--- a/src/StackDependency.hs
+++ b/src/StackDependency.hs
@@ -1,44 +1,31 @@
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module StackDependency where
 
-import           Control.Exception.Safe (throwM, Exception(..), MonadThrow)
+import           Control.Exception.Safe (Exception(..), MonadThrow, throwM)
 import           Control.Monad.Reader (runReaderT)
 import           Control.Monad.Reader.Class (MonadReader(..))
 import           Data.Function ((&))
-import           Data.Graph.Inductive.Graph ( empty
-                                            , mkGraph
-                                            , lab
-                                            , LNode
-                                            , LEdge
-                                            , Graph(..)
-                                            )
+import           Data.Graph.Inductive.Graph (Graph(..), LEdge, LNode, empty, lab, mkGraph)
 import qualified Data.Graph.Inductive.PatriciaTree as G
-import           Data.Graph.Inductive.Query.DFS (topsort', scc)
+import           Data.Graph.Inductive.Query.DFS (scc, topsort')
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (mapMaybe, catMaybes)
-import           Data.Monoid ((<>))
-import qualified Data.Set as Set
+import           Data.Maybe (catMaybes, mapMaybe)
 import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text, pack, unpack)
 import qualified Data.Text as Text
-import           Data.Text (pack, unpack, Text)
-import           Data.Tuple.Extra (first, dupe)
+import           Data.Tuple.Extra (dupe, first)
 import           Network.AWS.Data.Text (ToText(..))
 import           Network.AWS.S3.Types (BucketName(..))
-import           Text.Trifecta (parseString, Result(..))
+import           Text.Trifecta (Result(..), parseString)
 
-import           StackParameters ( parameterValue
-                                 , getParameters
-                                 , BucketFiles(..)
-                                 , ParameterValue(..)
-                                 , StackDescription(..)
-                                 )
-import           Types ( AWSAccountID
-                       , OutputName(..)
-                       , StackName(..)
-                       , StackOutputName(..))
+import           StackParameters
+                  (BucketFiles(..), ParameterValue(..), StackDescription(..), getParameters,
+                  parameterValue)
+import           Types (AWSAccountID, OutputName(..), StackName(..), StackOutputName(..))
 
 -- An edge from stack1 to stack2 implies that stack1 must exist before stack2
 -- can be created, i.e. stack2 is dependent on stack1

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -5,8 +5,7 @@ module Types where
 import           Control.Exception.Safe (Exception(..))
 import           Data.Hashable (Hashable)
 import           Data.HashMap.Lazy (HashMap)
-import           Data.Monoid ((<>))
-import           Data.Text (unpack, Text)
+import           Data.Text (Text, unpack)
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.5
+resolver: lts-15.10
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -18,6 +18,6 @@ extra-package-dbs: []
 
 ghc-options:
     # All packages
-    "*": -Wall
+    "$locals": -Wall
 
 apply-ghc-options: targets

--- a/test/ExternalValuesSpec.hs
+++ b/test/ExternalValuesSpec.hs
@@ -1,30 +1,21 @@
 module ExternalValuesSpec (main, spec) where
 
-import Control.Lens ((&), (?~))
-import Control.Monad.Reader (runReaderT)
-import Control.Monad.Trans.AWS (newEnv, Credentials(..))
-import Network.AWS.CloudFormation ( output
-                                  , oOutputKey
-                                  , oOutputValue
-                                  )
-import Network.AWS.Auth (AccessKey(..), SecretKey(..))
-import Network.AWS.CloudFormation.Types (OnFailure(..))
-import Network.AWS.S3.Types (BucketName(..))
-import Test.Hspec (describe, context, it, hspec, Spec)
-import Test.Hspec.Expectations.Pretty ( shouldBe
-                                      , shouldThrow
-                                      )
+import           Control.Lens ((&), (?~))
+import           Control.Monad.Reader (runReaderT)
+import           Control.Monad.Trans.AWS (Credentials(..), newEnv)
+import           Network.AWS.Auth (AccessKey(..), SecretKey(..))
+import           Network.AWS.CloudFormation (oOutputKey, oOutputValue, output)
+import           Network.AWS.CloudFormation.Types (OnFailure(..))
+import           Network.AWS.S3.Types (BucketName(..))
+import           Test.Hspec (Spec, context, describe, hspec, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldThrow)
 
-import ExternalValues ( mapStackOutputsToExternalValues
-                      , inlineBucketNames
-                      , loadPV
-                      , Context(..)
-                      , EnvironmentValueNotFound(..)
-                      , StackOutputNotFound(..)
-                      , InvalidBucketName(..)
-                      )
-import StackParameters (BucketFiles(..), ParameterValue(..))
-import Types (StackOutputName(..), StackName(..), HashNotFound(..))
+import           ExternalValues
+                  (Context(..), EnvironmentValueNotFound(..), InvalidBucketName(..),
+                  StackOutputNotFound(..), inlineBucketNames, loadPV,
+                  mapStackOutputsToExternalValues)
+import           StackParameters (BucketFiles(..), ParameterValue(..))
+import           Types (HashNotFound(..), StackName(..), StackOutputName(..))
 
 main :: IO ()
 main = hspec spec

--- a/test/HashSpec.hs
+++ b/test/HashSpec.hs
@@ -1,15 +1,11 @@
 module HashSpec (spec, main) where
 
-import Network.AWS.S3.Types (BucketName(..))
-import Test.Hspec (describe, context, it, hspec, Spec)
-import Test.Hspec.Expectations.Pretty (shouldBe, shouldThrow)
+import           Network.AWS.S3.Types (BucketName(..))
+import           Test.Hspec (Spec, context, describe, hspec, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldThrow)
 
-import Hash ( inlineHashes
-            , createHash
-            , HashNotFound(..)
-            , FileOrFolderDoesNotExist(..)
-            )
-import StackParameters (BucketFiles(..))
+import           Hash (FileOrFolderDoesNotExist(..), HashNotFound(..), createHash, inlineHashes)
+import           StackParameters (BucketFiles(..))
 
 main :: IO ()
 main = hspec spec

--- a/test/LoggingSpec.hs
+++ b/test/LoggingSpec.hs
@@ -1,34 +1,17 @@
 module LoggingSpec (spec, main) where
 
-import Control.Monad.Except (runExceptT)
-import Data.Either.Combinators (fromRight')
-import Data.Monoid ((<>))
-import Network.AWS.S3.Types (BucketName(..))
-import Network.AWS.Types (Region(..))
-import Test.Hspec ( describe
-                  , context
-                  , shouldBe
-                  , shouldSatisfy
-                  , it
-                  , hspec
-                  , Spec
-                  )
+import           Control.Monad.Except (runExceptT)
+import           Data.Either.Combinators (fromRight')
+import           Network.AWS.S3.Types (BucketName(..))
+import           Network.AWS.Types (Region(..))
+import           Test.Hspec (Spec, context, describe, hspec, it, shouldBe, shouldSatisfy)
 
-import Configuration (Command(..))
-import Logging ( logMain
-               , logGeneral
-               , logStackName
-               , logExecution
-               , logStackOutputs
-               , logFileUpload
-               , logZip
-               , filterBuilderBy
-               , LogParameters(..)
-               )
-import StackParameters (getStackParameters, StackDescription(..))
-import Types ( StackName(..)
-             , StackOutputName(..)
-             )
+import           Configuration (Command(..))
+import           Logging
+                  (LogParameters(..), filterBuilderBy, logExecution, logFileUpload, logGeneral,
+                  logMain, logStackName, logStackOutputs, logZip)
+import           StackParameters (StackDescription(..), getStackParameters)
+import           Types (StackName(..), StackOutputName(..))
 
 main :: IO ()
 main = hspec spec
@@ -39,21 +22,21 @@ spec = describe "LoggingSpec" $ do
     it "can generate a main log message" $ do
       stackParams <- runExceptT . getStackParameters $ "test/valid.yaml"
       let descriptions = fromRight' stackParams
-      let accountID = "478156153062"
+      let accountID = "478156153XXX"
       let logParams = LogParameters Create descriptions accountID Sydney
       let logMessage = logMain logParams
       logMessage `shouldBe`
            "\nCommand being executed: "
         <> "Create"
         <> "\nAWS Account ID: "
-        <> "478156153062"
+        <> "478156153XXX"
         <> "\nRegion: ap-southeast-2"
         <> "\nStack(s) being operated on:"
         <> "\n    Stack1"
         <> "\n    Stack2"
 
     it "can generate a general log message" $ do
-      let accountID = "478156153062"
+      let accountID = "478156153XXX"
       let logMessage = logGeneral Create accountID Sydney
       logMessage `shouldBe`
            "\nCommand being executed: "

--- a/test/LoggingSpec.hs
+++ b/test/LoggingSpec.hs
@@ -42,7 +42,7 @@ spec = describe "LoggingSpec" $ do
            "\nCommand being executed: "
         <> "Create"
         <> "\nAWS Account ID: "
-        <> "478156153062"
+        <> "478156153XXX"
         <> "\nRegion: ap-southeast-2"
 
     it "can generate a stack name log message" $ do

--- a/test/S3Spec.hs
+++ b/test/S3Spec.hs
@@ -1,9 +1,9 @@
 module S3Spec where
 
-import Test.Hspec (describe, context, it, hspec, Spec)
-import Test.Hspec.Expectations.Pretty (shouldBe)
+import           Test.Hspec (Spec, context, describe, hspec, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe)
 
-import S3 (makeS3FilePath)
+import           S3 (makeS3FilePath)
 
 main :: IO ()
 main = hspec spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,4 @@
-import Test.Hspec
+import           Test.Hspec
 
 import qualified ExternalValuesSpec
 import qualified HashSpec

--- a/test/StackDependencySpec.hs
+++ b/test/StackDependencySpec.hs
@@ -1,33 +1,19 @@
 module StackDependencySpec (spec, main) where
 
-import Control.Monad.Catch (MonadThrow)
-import Control.Monad.IO.Class (MonadIO(..))
-import Control.Monad.Reader (runReaderT)
-import Network.AWS.S3.Types (BucketName(..))
-import Test.Hspec ( describe
-                  , context
-                  , it
-                  , hspec
-                  , Spec
-                  )
-import Test.Hspec.Expectations.Pretty (shouldBe, shouldThrow)
+import           Control.Monad.Catch (MonadThrow)
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Reader (runReaderT)
+import           Network.AWS.S3.Types (BucketName(..))
+import           Test.Hspec (Spec, context, describe, hspec, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldThrow)
 
-import StackDependency ( makeStackDependencyGraph
-                       , parameterValueToDependency
-                       , getStackOutputBucketName
-                       , determineStackOrdering
-                       , StackDependencyGraph
-                       , StackNodeMap
-                       , StackReference(..)
-                       , DependencyCycleDetected(..)
-                       , UnknownStackReference(..)
-                       )
-import StackParameters ( getStackParameters
-                       , Capabilities(..)
-                       , ParameterValue(..)
-                       , StackDescription(..)
-                       )
-import Types (OutputName(..), StackName(..), StackOutputName(..))
+import           StackDependency
+                  (DependencyCycleDetected(..), StackDependencyGraph, StackNodeMap,
+                  StackReference(..), UnknownStackReference(..), determineStackOrdering,
+                  getStackOutputBucketName, makeStackDependencyGraph, parameterValueToDependency)
+import           StackParameters
+                  (Capabilities(..), ParameterValue(..), StackDescription(..), getStackParameters)
+import           Types (OutputName(..), StackName(..), StackOutputName(..))
 
 main :: IO ()
 main = hspec spec

--- a/test/StackParametersSpec.hs
+++ b/test/StackParametersSpec.hs
@@ -1,50 +1,25 @@
 module StackParametersSpec (spec, main) where
 
-import Control.Lens ((&), (?~))
-import Control.Lens.Extras (is)
-import Control.Monad.Except (runExceptT)
-import Data.Either.Combinators (fromRight')
-import Data.Text (Text)
-import Data.Yaml (ParseException)
-import Network.AWS (Region(Sydney))
-import Network.AWS.CloudFormation ( parameter
-                                  , pParameterKey
-                                  , pParameterValue
-                                  , tag
-                                  , tagKey
-                                  , tagValue
-                                  , Capability(..)
-                                  )
-import Network.AWS.S3.Types (BucketName(..))
-import Test.Hspec ( describe
-                  , context
-                  , it
-                  , hspec
-                  , Selector
-                  , Spec
-                  )
-import Test.Hspec.Expectations.Pretty ( shouldBe
-                                      , shouldThrow
-                                      , shouldSatisfy
-                                      , shouldReturn
-                                      )
-import Text.Trifecta (parseString, _Failure, Result(..))
+import           Control.Lens ((&), (?~))
+import           Control.Lens.Extras (is)
+import           Control.Monad.Except (runExceptT)
+import           Data.Either.Combinators (fromRight')
+import           Data.Text (Text)
+import           Data.Yaml (ParseException)
+import           Network.AWS (Region(Sydney))
+import           Network.AWS.CloudFormation
+                  (Capability(..), pParameterKey, pParameterValue, parameter, tag)
+import           Network.AWS.S3.Types (BucketName(..))
+import           Test.Hspec (Selector, Spec, context, describe, hspec, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldReturn, shouldSatisfy, shouldThrow)
+import           Text.Trifecta (Result(..), parseString, _Failure)
 
-import StackParameters ( getStackParameters
-                       , withinCurlyBracePair
-                       , envVarName
-                       , hashFilePath
-                       , stackOutputName
-                       , innerText
-                       , convertToStackParameters
-                       , convertToTags
-                       , getParameters
-                       , BucketFiles(..)
-                       , StackDescription(..)
-                       , ParameterValue(..)
-                       , Capabilities(..)
-                       )
-import Types (EnvironmentNotFound(..), StackName(..), StackOutputName(..))
+import           StackParameters
+                  (BucketFiles(..), Capabilities(..), ParameterValue(..), StackDescription(..),
+                  convertToStackParameters, convertToTags, envVarName, getParameters,
+                  getStackParameters, hashFilePath, innerText, stackOutputName,
+                  withinCurlyBracePair)
+import           Types (EnvironmentNotFound(..), StackName(..), StackOutputName(..))
 
 main :: IO ()
 main = hspec spec
@@ -64,10 +39,8 @@ spec = describe "StackParametersSpec" $ do
 
   context "loading tags" $
     it "can convert from Tags to AWS Tag" $
-      convertToTags [("tag1", "value1"), ("tag2", "value2")] `shouldBe` [
-          (tag & tagKey ?~ "tag1" & tagValue ?~ "value1")
-        , (tag & tagKey ?~ "tag2" & tagValue ?~ "value2")
-      ]
+      convertToTags [("tag1", "value1"), ("tag2", "value2")] `shouldBe`
+        [ tag "tag1" "value1" , tag "tag2" "value2" ]
 
   context "getting environment" $ do
     it "can get list of Parameters from Environments and an AWSAccount" $
@@ -267,7 +240,7 @@ spec = describe "StackParametersSpec" $ do
 
 shouldParse :: (Eq a, Show a) => Result a -> a -> IO ()
 shouldParse (Success a) expected = a `shouldBe` expected
-shouldParse (Failure err) _ = fail . show $ err
+shouldParse (Failure err) _      = fail . show $ err
 
 shouldFailParsing :: Show a => Result a -> IO ()
 shouldFailParsing result = result `shouldSatisfy` is _Failure

--- a/test/ZipSpec.hs
+++ b/test/ZipSpec.hs
@@ -1,15 +1,15 @@
 module ZipSpec (spec, main) where
 
-import Control.Monad.Trans.Resource (runResourceT)
-import Data.Text (pack)
-import Network.AWS.S3.Types (BucketName(..))
-import System.FilePath ( (</>) )
-import Test.Hspec (describe , context , it , hspec , Spec)
-import Test.Hspec.Expectations.Pretty (shouldBe, shouldThrow)
+import           Control.Monad.Trans.Resource (runResourceT)
+import           Data.Text (pack)
+import           Network.AWS.S3.Types (BucketName(..))
+import           System.FilePath ((</>))
+import           Test.Hspec (Spec, context, describe, hspec, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldThrow)
 
-import StackParameters (BucketFiles(..))
-import Types (FileOrFolderDoesNotExist(..))
-import Zip (inlineZips, writeZip, getPathInArchive)
+import           StackParameters (BucketFiles(..))
+import           Types (FileOrFolderDoesNotExist(..))
+import           Zip (getPathInArchive, inlineZips, writeZip)
 
 main :: IO ()
 main = hspec spec


### PR DESCRIPTION
Welcome to the 21st century, evaporate! Most of the changes come from applying the stylish-haskell config we use for other internal projects to the whole project. All the function changes are to make the project compile with new LTSs.

The only thing I'm unsure about is the change to throwing instead of using `fail`
```diff
- Failure _ -> fail . unpack $ t <> " is not a valid value"
+ Failure _ -> throwM $ InvalidBucketName $ t <> " is not a valid value"
```

I couldn't tell why it was using fail, and there isn't an instance for MonaFail for AWST.